### PR TITLE
Fix peak persisting when it shouldn't

### DIFF
--- a/drawer-behavior/src/main/java/com/jakewharton/behavior/drawer/BehaviorDelegate.java
+++ b/drawer-behavior/src/main/java/com/jakewharton/behavior/drawer/BehaviorDelegate.java
@@ -214,6 +214,9 @@ final class BehaviorDelegate extends ViewDragHelper.Callback {
   }
 
   private void closeDrawers(boolean peekingOnly) {
+
+    removeCallbacks();
+
     if (peekingOnly && !isPeeking) {
       return;
     }
@@ -225,8 +228,6 @@ final class BehaviorDelegate extends ViewDragHelper.Callback {
       needsSettle = dragger.smoothSlideViewTo(child, parent.getWidth(), child.getTop());
     }
     isPeeking = false;
-
-    removeCallbacks();
 
     if (needsSettle) {
       ViewCompat.postOnAnimation(parent, draggerSettle);


### PR DESCRIPTION
Fix for #11 
removeCallbacks should always be called in closeDrawers. This is how it is implemented in DrawerLayout.
