### PR TITLE
Add behavior name resource

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,17 @@
+language: android
+android:
+  components:
+  - tools
+  - platform-tools
+  - build-tools-23.0.3
+  - android-23
+  - extra-google-google_play_services
+  - extra-google-m2repository
+  - extra-android-m2repository
+jdk:
+- oraclejdk8
+before_install:
+- chmod +x gradlew
+notifications:
+  slack: heinrichreimer:twzJpzYgSjWnT0QCIoMeIa7l
+  

--- a/README.md
+++ b/README.md
@@ -1,15 +1,12 @@
-Drawer Behavior for CoordinatorLayout
-=====================================
+# Drawer Behavior (for `CoordinatorLayout`)
 
-A `CoordinatorLayout` behavior which mimics the functionality of `DrawerLayout`.
+[![Build Status](https://travis-ci.org/heinrichreimer/android-drawer-behavior.svg?branch=master)](https://travis-ci.org/heinrichreimer/android-drawer-behavior)
 
-TODO explain why
+_A `CoordinatorLayout` behavior which mimics the functionality of `DrawerLayout`._
 
-TODO embed gif
-
-TODO download section
-
-
+- **TODO:** Explain why
+- **TODO:** Embed GIF
+- **TODO:** Download section
 
 License
 -------

--- a/drawer-behavior/src/main/res/values/strings.xml
+++ b/drawer-behavior/src/main/res/values/strings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="drawer_behavior">com.jakewharton.behavior.drawer.DrawerBehavior</string>
+</resources>


### PR DESCRIPTION
With this people can use the behavior by referencing `@string/drawer_behavior` similar to how this is done by the support library.